### PR TITLE
Fix require: lodash / underscore

### DIFF
--- a/lib/moment-duration-format.js
+++ b/lib/moment-duration-format.js
@@ -67,7 +67,11 @@
 
 	if (hasRequire) {
 		// require lodash or underscore
-		_ = require('lodash') || require('underscore');
+		try {
+			_ = require('lodash');
+		} catch (e) {
+			_ = require('underscore');
+		}
 	} else if (root._) {
 		_ = root._;
 	} else {


### PR DESCRIPTION
Allow underscore to be required if lodash is unavailable.
