### PR TITLE
Added support for commonjs, AMD and browser globals using UMD pattern

### DIFF
--- a/lib/moment-duration-format.js
+++ b/lib/moment-duration-format.js
@@ -22,7 +22,7 @@
         module.exports = factory(require('moment'));
     } else {
         // Browser globals
-        root.returnExportsGlobal = factory(root.moment);
+        root.moment = factory(root.moment);
     }
 }(this, function (moment) {
 

--- a/lib/moment-duration-format.js
+++ b/lib/moment-duration-format.js
@@ -9,7 +9,22 @@
  *  Released under the MIT license
  */
 
-(function (root, undefined) {
+(function (root, factory) {
+    if (typeof define === 'function' && define.amd) {
+        // AMD. Register as an anonymous module.
+        define(['moment'], function (moment) {
+            return (root.returnExportsGlobal = factory(moment));
+        });
+    } else if (typeof exports === 'object') {
+        // Node. Does not work with strict CommonJS, but
+        // only CommonJS-like enviroments that support module.exports,
+        // like Node.
+        module.exports = factory(require('moment'));
+    } else {
+        // Browser globals
+        root.returnExportsGlobal = factory(root.moment);
+    }
+}(this, function (moment) {
 
 	// repeatZero(qty)
 	// returns "0" repeated qty times
@@ -182,18 +197,6 @@
 		return a;
 	}
 			
-	// define internal moment reference
-	var moment;
-
-	if (typeof require === "function") {
-		try { moment = require('moment'); } 
-		catch (e) {}
-	} 
-	
-	if (!moment && root.moment) {
-		moment = root.moment;
-	}
-	
 	if (!moment) {
 		throw "Moment Duration Format cannot find Moment.js";
 	}
@@ -479,4 +482,6 @@
 		}
 	};
 
-})(this);
+	return moment;
+}));
+


### PR DESCRIPTION
I like moment-duration-format and use it in two web apps one use browserify and commonjs the other use AMD and requirejs. So I created this fork to be able to support both of them.