### PR TITLE
add failing test for trimming

### DIFF
--- a/test/moment-duration-format-tests.js
+++ b/test/moment-duration-format-tests.js
@@ -24,6 +24,7 @@ $(document).ready(function() {
 	test("Trim Right", function () {
 		equal(moment.duration(1, "seconds").format("s m", { trim: "right" }), "1");
 		equal(moment.duration(1, "minutes").format("s m h", { trim: "right" }), "0 1");
+		equal(moment.duration({ years: 2, months: 0 }).format("Y [years] M [months]", { trim: "right" }), "2 years");
 	});
 
 	test("Trim False", function () {


### PR DESCRIPTION
Hi, I dont quite get the trimming feature. this pr adds a test for what I want to achieve, but fails with:

``` shell
Expected:   
"2 years"
Result:     
"2 years 0"
Diff:   
 "2 years" years 0"
```

Is this possible somehow?
