### PR TITLE
UMD loader added

### DIFF
--- a/lib/moment-duration-format.js
+++ b/lib/moment-duration-format.js
@@ -9,8 +9,20 @@
  *  Released under the MIT license
  */
 
-(function (root, undefined) {
-
+(function (root, factory) {
+	if (typeof define === 'function' && define.amd) {
+		// AMD. Register as an anonymous module.
+		define(['moment'], factory);
+	} else if (typeof exports === 'object') {
+		// Node. Does not work with strict CommonJS, but
+		// only CommonJS-like environments that support module.exports,
+		// like Node.
+		module.exports = factory(require('moment'));
+	} else {
+		// Browser globals (root is window)
+		factory(root.moment);
+	}
+}(this, function (moment) {
 	// repeatZero(qty)
 	// returns "0" repeated qty times
 	function repeatZero(qty) {
@@ -181,23 +193,7 @@
 		
 		return a;
 	}
-			
-	// define internal moment reference
-	var moment;
 
-	if (typeof require === "function") {
-		try { moment = require('moment'); } 
-		catch (e) {}
-	} 
-	
-	if (!moment && root.moment) {
-		moment = root.moment;
-	}
-	
-	if (!moment) {
-		throw "Moment Duration Format cannot find Moment.js";
-	}
-	
 	// moment.duration.format([template] [, precision] [, settings])
 	moment.duration.fn.format = function () {
 
@@ -479,4 +475,4 @@
 		}
 	};
 
-})(this);
+}));


### PR DESCRIPTION
This adds [UMD](https://github.com/umdjs/umd) to moment-duration-format and makes it compatible with AMD, CommenJS and Browser environments.

