### PR TITLE
Rudimentary support for handling proper pluralisation of units

### DIFF
--- a/lib/moment-duration-format.js
+++ b/lib/moment-duration-format.js
@@ -201,7 +201,7 @@
 	// moment.duration.format([template] [, precision] [, settings])
 	moment.duration.fn.format = function () {
 
-		var tokenizer, tokens, types, typeMap, momentTypes, foundFirst, trimIndex,
+		var tokenizer, tokens, types, typeMap, momentTypes, foundFirst, trimIndex, lastValue,
 			args = [].slice.call(arguments),
 			settings = extend({}, this.format.defaults),
 			// keep a shadow copy of this moment for calculating remainders
@@ -351,7 +351,12 @@
 
 			if (!token.type) {
 				// if it is not a moment token, use the token as its own value
-				return token.token;
+				if (token.token.match(/s?$/)) {
+					// tokens in the form 'minutes?' will be transformed to 'minute' or 'minutes' as appropriate
+					return token.token.replace(/s\?$/, (Math.abs(lastValue) === 1) ? '' : 's');
+				} else {
+					return token.token;
+				}
 			}
 
 			// apply negative precision formatting to the least-significant moment token
@@ -360,7 +365,9 @@
 			} else {
 				val = token.wholeValue.toString();
 			}
-			
+
+			lastValue = parseInt(val, 10);
+
 			// remove negative sign from the beginning
 			val = val.replace(/^\-/, "");
 

--- a/test/moment-duration-format-tests.js
+++ b/test/moment-duration-format-tests.js
@@ -191,4 +191,10 @@ $(document).ready(function() {
 		equal(moment.duration(-65.667, "days").format("d", 2), "-65.66");
 		equal(moment.duration(-65.667, "days").format("d [days], h [hours]"), "-65 days, 16 hours");
 	});
+
+	test("Pluralisation support", function () {
+		equal(moment.duration(1, 'minutes').format('m [minutes?]'), '1 minute');
+		equal(moment.duration(2, 'minutes').format('m [minutes?]'), '2 minutes');
+		equal(moment.duration(1, 'year').format('m [minutes?]'), '525600 minutes');
+	});
 });


### PR DESCRIPTION
This commit adds the ability to write format strings like `"m [minutes?]"` to have `format()` pluralise the unit correctly: The 's' will be dropped or included based on the value of the previous time field in the format string.

It's very simple, of course, and could probably use more flexibility.