### PR TITLE
Add Typescript definition

### DIFF
--- a/moment-duration-format.d.ts
+++ b/moment-duration-format.d.ts
@@ -1,0 +1,7 @@
+declare namespace moment {
+
+    interface Duration {
+        format(format: string): string;
+    }
+
+}

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "moment-duration-format",
-	"version": "1.3.0",
+	"version": "1.3.1",
 	"description": "A moment.js plugin for formatting durations.",
 	"main": "lib/moment-duration-format.js",
 	"repository": {
@@ -19,5 +19,6 @@
 	"bugs": {
 		"url": "https://github.com/jsmreese/moment-duration-format/issues"
 	},
-	"homepage": "https://github.com/jsmreese/moment-duration-format"
+	"homepage": "https://github.com/jsmreese/moment-duration-format",
+	"types": "./moment-duration-format.d.ts"
 }


### PR DESCRIPTION
I have added a Typescript definition file as I am increasingly using this module in Typescript projects and having a definition means editors provide context help on the duration extension method.
