### PR TITLE
Enable setup on custom moment.js instance

### DIFF
--- a/README.md
+++ b/README.md
@@ -49,6 +49,7 @@ var momentDurationSetup = require("moment-duration-format");
 momentDurationSetup(moment)
 // typeof moment.duration().format === function
 // => true
+```
 
 ### Basics
 

--- a/README.md
+++ b/README.md
@@ -34,7 +34,7 @@ When using this plugin in the browser, be sure to include moment.js on your page
 
 To use this plugin as a module, use the `require` function:
 
-```
+```js
 var moment = require("moment");
 require("moment-duration-format");
 ```
@@ -43,7 +43,7 @@ Using the plugin with standard `moment.js` package should work out of the box an
 
 To use it with any other `moment.js` package, for example `moment-timezone`, manually call the exported setup function to install the plugin into `moment`, as following:
 
-```
+```js
 var moment = require("moment-timezone");
 var momentDurationSetup = require("moment-duration-format");
 momentDurationSetup(moment)
@@ -54,7 +54,7 @@ momentDurationSetup(moment)
 
 The duration format method can format any moment duration. If no template or other arguments are provided, the default template function will generate a template string based on the duration's value.
 
-```
+```js
 moment.duration(123, "minutes").format();
 // "2:03:00"
 
@@ -63,7 +63,7 @@ moment.duration(123, "months").format();
 ```
 
 The duration format method may be called with three optional arguments:
-```
+```js
 moment.duration.format([template] [, precision] [, settings])
 ```
 
@@ -71,13 +71,13 @@ moment.duration.format([template] [, precision] [, settings])
 
 `template` (string|function) is the string used to create the formatted output, or a function that returns the string to be used as the format template.
 
-```
+```js
 moment.duration(123, "minutes").format("h:mm");
 // "2:03"
 ```
 
 The template string is parsed for moment-token characters, which are replaced with the duration's value for each unit type. The default tokens are:
-```
+```js
 years:   Y or y
 months:  M
 weeks:   W or w
@@ -91,7 +91,7 @@ ms:      S
 Token characters may be customized ([see below for an example](\#tokens)).
 
 Escape token characters within the template string using square brackets.
-```
+```js
 moment.duration(123, "minutes").format("h [hrs], m [min]");
 // "2 hrs, 3 min"
 ```
@@ -105,19 +105,19 @@ Escape characters may also be customized ([see below for an example](\#escape)).
 `precision` (number) defines the number of digits to display for the final value.
 
 The default precison value is `0`.
-```
+```js
 moment.duration(123, "minutes").format("h [hrs]");
 // "2 hrs"
 ```
 
 Positive precision defines the number of digits to display to the right of the decimal point.
-```
+```js
 moment.duration(123, "minutes").format("h [hrs]", 2);
 // "2.04 hrs"
 ```
 
 Negative precision will truncate the value to the left of the decimal point.
-```
+```js
 moment.duration(123, "minutes").format("m [min]", -1);
 // "120 min"
 ```
@@ -128,7 +128,7 @@ moment.duration(123, "minutes").format("m [min]", -1);
 
 Both the `template` and `precision` arguments may be specified as properties of a single `settings` object argument, or they may be passed separately along with an optional settings object.
 
-```
+```js
 moment.duration(123, "minutes").format({ template: "h [hrs]", precision: 2 });
 // "2.04 hrs"
 ```
@@ -136,19 +136,19 @@ moment.duration(123, "minutes").format({ template: "h [hrs]", precision: 2 });
 #### Trim
 
 Leading tokens are automatically trimmed when they have no value.
-```
+```js
 moment.duration(123, "minutes").format("d[d] h:mm:ss");
 // "2:03:00"
 ```
 
 To stop that behavior, set `{ trim: false }`.
-```
+```js
 moment.duration(123, "minutes").format("d[d] h:mm:ss", { trim: false });
 // "0d 2:03:00"
 ```
 
 Use `{ trim: "right" }` to trim from the right.
-```
+```js
 moment.duration(123, "minutes").format("[seconds:] s -- [minutes:] m -- [hours:] h -- [days:] d", { trim: "right" });
 // "seconds: 0 -- minutes: 3 -- hours: 2"
 ```
@@ -157,21 +157,21 @@ moment.duration(123, "minutes").format("[seconds:] s -- [minutes:] m -- [hours:]
 
 Force the first moment token with a value to render at full length, even when the template is trimmed and the first moment token has a length of 1. Sounds more complicated than it is.
 
-```
+```js
 moment.duration(123, "seconds").format("h:mm:ss");
 // "2:03"
 ```
 
 If you want minutes to always be rendered with two digits, you can set the first token to a length greater than 1 (this stops the automatic length trimming for the first token that has a value).
 
-```
+```js
 moment.duration(123, "seconds").format("hh:mm:ss");
 // "02:03"
 ```
 
 Or you can use `{ forceLength: true }`.
 
-```
+```js
 moment.duration(123, "seconds").format("h:mm:ss", { forceLength: true });
 // "02:03"
 ```
@@ -180,7 +180,7 @@ moment.duration(123, "seconds").format("h:mm:ss", { forceLength: true });
 
 Show only the largest `n` moment tokens that have values. All subsequent moment tokens will be trimmed. Set to a positive integer to enable. Not compatible with the `trim: "right"` option.
 
-```
+```js
 moment.duration(2.55, "days").format("d [days], h [hours], m [minutes], s [seconds]", { largest: 2 });
 // "2 days, 13 hours"
 ```
@@ -195,7 +195,7 @@ Default escape token regexp: `/\[(.+?)\]/`
 
 Define something other than square brackets as escape characters.
 
-```
+```js
 moment.duration.fn.format.defaults.escape = /\((.+?)\)/;
 moment.duration(123, "seconds").format("m (minutes)", 2);
 // "2.04 minutes"
@@ -207,7 +207,7 @@ Default years token regexp: `/[Yy]+/`
 
 Define years token for spanish language formatting.
 
-```
+```js
 moment.duration.fn.format.defaults.years = /[Aa]+/;
 moment.duration(123, "weeks").format("a [años]", 2);
 // "2.35 años"
@@ -219,7 +219,7 @@ Default months token regexp: `/M+/`
 
 Define months token to use only lower-case `m`.
 
-```
+```js
 moment.duration.fn.format.defaults.months = /m+/;
 moment.duration(123, "weeks").format("m M", 2);
 // "28.36 M"
@@ -231,7 +231,7 @@ Default weeks token regexp: `/[Ww]+/`
 
 Define weeks token to use only lower-case `w`.
 
-```
+```js
 moment.duration.fn.format.defaults.weeks = /w+/;
 moment.duration(123, "days").format("w W", 2);
 // "17.57 W"
@@ -243,7 +243,7 @@ Default days token regexp: `/[Dd]+/`
 
 Define days token to use only lower-case `d`.
 
-```
+```js
 moment.duration.fn.format.defaults.days = /d+/;
 moment.duration(123, "hours").format("d D", 2);
 // "5.12 D"
@@ -255,7 +255,7 @@ Default hours token regexp: `/[Hh]+/`
 
 Define hours token to use only lower-case `h`.
 
-```
+```js
 moment.duration.fn.format.defaults.hours = /h+/;
 moment.duration(123, "minutes").format("h H", 2);
 // "2.04 H"
@@ -267,7 +267,7 @@ Default minutes token regexp: `/m+/`
 
 Define minutes token to use only lower-case `n`.
 
-```
+```js
 moment.duration.fn.format.defaults.minutes = /n+/;
 moment.duration(123, "seconds").format("n:ss");
 // "2:03"

--- a/README.md
+++ b/README.md
@@ -33,13 +33,22 @@ When using this plugin in the browser, be sure to include moment.js on your page
 ### Module
 
 To use this plugin as a module, use the `require` function:
+
 ```
+var moment = require("moment");
 require("moment-duration-format");
 ```
 
-The plugin does not export anything, so there is no need to assign the require output to a variable.
+Using the plugin with standard `moment.js` package should work out of the box and not require any further setup.
 
-The plugin depends on moment.js, which is not specified as a package dependency in the currently published version.
+To use it with any other `moment.js` package, for example `moment-timezone`, manually call the exported setup function to install the plugin into `moment`, as following:
+
+```
+var moment = require("moment-timezone");
+var momentDurationSetup = require("moment-duration-format");
+momentDurationSetup(moment)
+// typeof moment.duration().format === function
+// => true
 
 ### Basics
 

--- a/lib/moment-duration-format.js
+++ b/lib/moment-duration-format.js
@@ -15,8 +15,14 @@
 		define(['moment'], factory);
 	} else if (typeof exports === 'object') {
 		// Node. Does not work with strict CommonJS, but only CommonJS-like
-        // enviroments that support module.exports, like Node.
-		module.exports = factory(require('moment'));
+		// enviroments that support module.exports, like Node.
+		try {
+			module.exports = factory(require('moment'))
+		} catch (e) {
+			// If moment is not available, leave the setup up to the user-friendly
+			// (for example when using moment-timezone or similar moment-based package)
+			module.exports = factory
+		}
 	} else {
 		// Browser globals.
 		root.momentDurationFormat = factory(root.moment);


### PR DESCRIPTION
Rel #47

- Export factory when moment package is not found (same as proposed in https://github.com/jsmreese/moment-duration-format/issues/23#issuecomment-75415919)
- Amend README

*Note: instead of hardcoding `moment-timezone` use case, I leave the setup step to the user. This seems more future-proof.*