### PR TITLE
Version update to 2.3.3

### DIFF
--- a/lib/moment-duration-format.js
+++ b/lib/moment-duration-format.js
@@ -12,12 +12,14 @@
 (function (root, factory) {
     if (typeof define === 'function' && define.amd) {
         // AMD. Register as an anonymous module.
-        define(['moment'], factory);
+        define(['moment'], function() {
+            return factory(require('moment').default);
+         });
     } else if (typeof exports === 'object') {
         // Node. Does not work with strict CommonJS, but only CommonJS-like
         // enviroments that support module.exports, like Node.
         try {
-            module.exports = factory(require('moment'));
+            module.exports = factory(require('moment').default);
         } catch (e) {
             // If moment is not available, leave the setup up to the user.
             // Like when using moment-timezone or similar moment-based package.
@@ -1543,7 +1545,6 @@
 
     // init
     function init(context) {
-        context = context.default;
         if (!context) {
             throw "Moment Duration Format init cannot find moment instance.";
         }

--- a/lib/moment-duration-format.js
+++ b/lib/moment-duration-format.js
@@ -1543,6 +1543,7 @@
 
     // init
     function init(context) {
+        context = context.default;
         if (!context) {
             throw "Moment Duration Format init cannot find moment instance.";
         }

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "moment-duration-format",
-	"version": "2.3.2",
+	"version": "2.3.3",
 	"description": "A moment.js plugin for formatting durations.",
 	"main": "lib/moment-duration-format.js",
 	"repository": {


### PR DESCRIPTION
context has been turned to an object {__esModule: true, default: ƒ} in moment js 2.25.0
This throws error on this repository